### PR TITLE
Default French output for summaries

### DIFF
--- a/src/llm_agent.py
+++ b/src/llm_agent.py
@@ -286,7 +286,7 @@ class LLMAgentSummary(LLMAgentBase):
         self.combine_prompt = combine_prompt
 
         if not self.combine_prompt:
-            translation_lang = os.getenv("TRANSLATION_LANG")
+            translation_lang = os.getenv("TRANSLATION_LANG", "French")
             print(f"[LLMAgentSummary] translation language: {translation_lang}, translation_enabled: {translation_enabled}")
 
             prompt_no_translation = llm_prompts.LLM_PROMPT_SUMMARY_COMBINE_PROMPT3
@@ -381,7 +381,7 @@ class LLMAgentTranslation(LLMAgentBase):
 
     def init_prompt(self, prompt=None, trans_lang=None):
         if not prompt:
-            translation_lang = trans_lang or os.getenv("TRANSLATION_LANG")
+            translation_lang = trans_lang or os.getenv("TRANSLATION_LANG", "French")
             print(f"[LLMAgentTranslation] translation language: {translation_lang}")
 
             prompt = llm_prompts.LLM_PROMPT_TRANSLATION.format(translation_lang) + "{content}"

--- a/src/llm_prompts.py
+++ b/src/llm_prompts.py
@@ -73,7 +73,7 @@ Avoid using phrases that directly reference 'the script provides' to maintain a 
 """
 
 LLM_PROMPT_SUMMARY_COMBINE_PROMPT2_SUFFIX = """
-NUMBERED LIST SUMMARY IN BOTH ENGLISH AND {}, AFTER FINISHING ALL ENGLISH PART, THEN FOLLOW BY {} PART, USE '===' AS THE SEPARATOR:
+NUMBERED LIST SUMMARY IN {}:
 """
 
 LLM_PROMPT_SUMMARY_COMBINE_PROMPT3 = """
@@ -91,7 +91,7 @@ As a professional summarizer, create a concise and comprehensive summary of the 
 """
 
 LLM_PROMPT_SUMMARY_COMBINE_PROMPT_SUFFIX = """
-NUMBERED LIST SUMMARY IN BOTH ENGLISH AND {}, AFTER FINISHING ALL ENGLISH PART, THEN FOLLOW BY {} PART, USE '===' AS THE SEPARATOR:
+NUMBERED LIST SUMMARY IN {}:
 """
 
 # One-liner summary
@@ -109,7 +109,7 @@ Your goal is to:
 
 # In case need a translation
 LLM_PROMPT_JOURNAL_MIDDLE = """
-- For all the above goals, write one English version, then translate it to {} (including insights, takeaways, and action items), and use === as the delimiter.
+- For all the above goals, write in {} only (including insights, takeaways, and action items).
 """
 
 LLM_PROMPT_JOURNAL_SUFFIX = """

--- a/src/ops_deepdive.py
+++ b/src/ops_deepdive.py
@@ -261,7 +261,8 @@ class OperatorDeepDive(OperatorBase):
                     latest_collection_content = dd_page["__deepdive_collection_updated"]
 
                 # After all iterations, do translation if needed
-                if os.getenv("TRANSLATION_LANG"):
+                translation_lang = os.getenv("TRANSLATION_LANG", "French")
+                if translation_lang:
                     llm_translation_response = llm_agent_trans.run(dd_page["__deepdive"])
                     print(f"LLM: Translation response: {llm_translation_response}")
                     dd_page["__translation_deepdive"] = llm_translation_response


### PR DESCRIPTION
## Summary
- default to French for summary and translation agents
- remove English/French split in summary prompts
- update journal prompt to only output one language
- translate deep dive results when translation language is configured or defaulted

## Testing
- `python -m py_compile src/llm_prompts.py src/llm_agent.py src/ops_deepdive.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4afa1d988324add1f935b3f963bd