### PR TITLE
Increase RSS filter capacity

### DIFF
--- a/src/af_save.py
+++ b/src/af_save.py
@@ -157,8 +157,8 @@ def process_rss(args):
         start_date=args.start,
         max_distance=args.max_distance)
 
-    # Only pick top 1 to reduce the overflow
-    data_filtered = op.filter(data_scored, k=1, min_score=4)
+    # Pick top 15 posts to keep more articles
+    data_filtered = op.filter(data_scored, k=15, min_score=4)
     data_summarized = op.summarize(data_filtered)
 
     targets = args.targets.split(",")


### PR DESCRIPTION
## Summary
- adjust RSS save step to allow more posts through filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e67c2359883248055c8140b3177ea